### PR TITLE
Potential fix for code scanning alert no. 13: DOM text reinterpreted as HTML

### DIFF
--- a/primary-app/src/Pages/Profile.jsx
+++ b/primary-app/src/Pages/Profile.jsx
@@ -6,10 +6,10 @@ import React, { useState } from 'react';
 
 // Helper function to validate avatar URLs
 function getSafeAvatarUrl(url) {
-	// Only allow http, https, or safe data:image URLs (no SVG)
-	if (
-		typeof url === 'string' &&
-		(
+	// Only allow http, https, or safe data:image URLs (no SVG or other dangerous types)
+	if (typeof url === 'string') {
+		// Disallow SVG images explicitly
+		if (
 			url.startsWith('https://') ||
 			url.startsWith('http://') ||
 			(
@@ -19,9 +19,16 @@ function getSafeAvatarUrl(url) {
 				url.startsWith('data:image/gif') ||
 				url.startsWith('data:image/webp')
 			)
-		)
-	) {
-		return url;
+		) {
+			// Extra check: reject any data:image/svg+xml or data:image/svg
+			if (
+				url.startsWith('data:image/svg') ||
+				url.startsWith('data:image/svg+xml')
+			) {
+				return 'https://placehold.co/150x150';
+			}
+			return url;
+		}
 	}
 	// Fallback to a default image if unsafe
 	return 'https://placehold.co/150x150';


### PR DESCRIPTION
Potential fix for [https://github.com/NathanielWilcox/PersonalDevelopmentProject/security/code-scanning/13](https://github.com/NathanielWilcox/PersonalDevelopmentProject/security/code-scanning/13)

To fix the problem, we need to ensure that the `avatar` property cannot be set to a malicious value, especially a `data:` URI with an SVG or JavaScript payload. The best way is to:

- Harden the `getSafeAvatarUrl` function to explicitly reject `data:image/svg+xml` and any other potentially dangerous image types.
- Optionally, only allow the avatar to be set from a controlled set of sources (e.g., only allow URLs from trusted domains, or only allow the default placeholder).
- If the avatar field is ever made editable, add a dedicated input with strict validation and sanitization.

For this code, we will update the `getSafeAvatarUrl` function to explicitly reject SVG images and any other non-image data URIs, and ensure that only safe URLs are allowed. This change is made in the `primary-app/src/Pages/Profile.jsx` file, specifically in the `getSafeAvatarUrl` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
